### PR TITLE
Implementação de T7 - Implementação da Lógica de Registro

### DIFF
--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/controller/AuthController.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/controller/AuthController.java
@@ -1,0 +1,39 @@
+package br.edu.ufape.plataforma.mentoria.controller;
+
+import br.edu.ufape.plataforma.mentoria.dto.UserDTO;
+import br.edu.ufape.plataforma.mentoria.model.User;
+import br.edu.ufape.plataforma.mentoria.security.TokenService;
+import br.edu.ufape.plataforma.mentoria.service.AuthService;
+import jakarta.validation.Valid;
+import org.apache.coyote.Response;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthenticationManager authenticationManager;
+    private final AuthService authService;
+    private final TokenService tokenService;
+
+    public AuthController(AuthenticationManager authenticationManager,
+                          AuthService authService, TokenService tokenService) {
+        this.authenticationManager = authenticationManager;
+        this.authService = authService;
+        this.tokenService = tokenService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<User> register(@RequestBody @Valid UserDTO userDTO){
+        User resgistredUser = this.authService.register(userDTO);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(resgistredUser);
+    }
+}

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/dto/UserDTO.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/dto/UserDTO.java
@@ -1,0 +1,51 @@
+package br.edu.ufape.plataforma.mentoria.dto;
+import br.edu.ufape.plataforma.mentoria.util.UserRole;
+public class UserDTO {
+
+    private String name;
+    private String email;
+    private String password;
+    private UserRole role;
+
+    public UserDTO() {
+        }
+
+    public UserDTO(String name, String email, String password, UserRole role) {
+            this.name = name;
+            this.email = email;
+            this.password = password;
+            this.role = role;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public UserRole getRole() {
+        return role;
+    }
+
+    public void setRole(UserRole role) {
+        this.role = role;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/AuthService.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/AuthService.java
@@ -1,0 +1,42 @@
+package br.edu.ufape.plataforma.mentoria.service;
+
+import br.edu.ufape.plataforma.mentoria.model.User;
+import br.edu.ufape.plataforma.mentoria.dto.UserDTO;
+import br.edu.ufape.plataforma.mentoria.repository.UserRepository;
+import jakarta.validation.constraints.Null;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+
+@Service
+public class AuthService implements UserDetailsService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return this.userRepository.findByEmail(username);
+    }
+
+    public User register(UserDTO userDTO){
+        UserDetails userDetails = this.userRepository.findByEmail(userDTO.getEmail());
+
+        if(userDetails != null){
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Email already taken!");
+        }
+
+        String encriptedPassword = new BCryptPasswordEncoder().encode(userDTO.getPassword());
+
+        User user = new User(userDTO.getName(), userDTO.getEmail(), encriptedPassword, userDTO.getRole());
+        return this.userRepository.save(user);
+
+    }
+
+}

--- a/backend/plataforma.mentoria/src/main/resources/application.properties
+++ b/backend/plataforma.mentoria/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=plataforma.mentoria
 
 # Dados de conexao com o banco H2
-spring.datasource.url=jdbc:h2:mem:myufapeanimedb
+spring.datasource.url=jdbc:h2:mem:plataforma-mentoria
 spring.datasource.username=sa
 spring.datasource.password=
 
@@ -14,3 +14,5 @@ spring.jpa.properties.hibernate.format_sql=true
 
 api.security.token.secret=senhasla
 
+# Habilita a exibição do SQL gerado pelo JPA no console
+spring.jpa.show-sql=true


### PR DESCRIPTION
Agora é possível criar novos usuários com o método POST para a URL /auth/register

O corpo da requisição deve seguir o formato JSON abaixo, e em caso de sucesso, a API retorna um status 201 Created

{
  "name": "nome",
  "email": "resenha@gmail.com",
  "password": "senha123",
  "role": "ADMIN"
}

Não é possível criar 2 usuários com o mesmo email e a senha passada é criptografada
