### PR TITLE
[refactor][auth]: Substitui papéis ADMIN/USER por MENTOR/MENTORADO

### DIFF
--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/model/User.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/model/User.java
@@ -92,11 +92,10 @@ public class User implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        if (this.role == UserRole.ADMIN) {
-            return List.of(new SimpleGrantedAuthority("ROLE_ADMIN"), 
-             new SimpleGrantedAuthority("ROLE_USER"));
+        if (this.role == UserRole.MENTOR) {
+            return List.of(new SimpleGrantedAuthority("ROLE_MENTOR"));
         } else {
-            return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+            return List.of(new SimpleGrantedAuthority("ROLE_MENTORADO"));
         }
     }
 

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/security/SecurityConfig.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/security/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(authorize -> authorize
             .anyRequest().permitAll()
             //.requestMatchers(HttpMethod.POST, "/auth/register").permitAll()
-            //.requestMatchers("/location/**", "/booking/**").hasRole("ADMIN")
+            //.requestMatchers("/location/**", "/booking/**").hasRole("MENTOR")
             //To-do: substituir as rodas, quando estas estiverem devidamente implementadas
             //.anyRequest().authenticated()
             )

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/util/UserRole.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/util/UserRole.java
@@ -2,8 +2,8 @@ package br.edu.ufape.plataforma.mentoria.util;
 
 public enum UserRole {
     
-    ADMIN("ADMIN"),
-    USER("USER");
+    MENTOR("MENTOR"),
+    MENTORADO("MENTORADO");
 
     private final String role;
 

--- a/frontend/src/app/auth/register/register.component.html
+++ b/frontend/src/app/auth/register/register.component.html
@@ -59,8 +59,8 @@
           <label for="role">Função</label>
           <select id="role" required>
             <option value="" disabled selected>Selecione um papel</option>
-            <option value="Mentor">Mentor</option>
-            <option value="Mentorado">Mentorado</option>
+            <option value="MENTOR">Mentor</option>
+            <option value="MENTORADO">Mentorado</option>
           </select>
         </div>
 


### PR DESCRIPTION
## Descrição do Pull Request

### Descrição  
Este Pull Request refatora o sistema de autorização para alinhar os papéis de usuário com o domínio da plataforma de mentoria.  
As roles genéricas `ADMIN` e `USER` foram substituídas pelos papéis específicos `MENTOR` e `MENTORADO`, tornando o código mais claro, legível e seguro ao garantir que as permissões sejam mutuamente exclusivas.

---

### Refatorações Realizadas

#### Renomeação dos Papéis de Usuário:
- Substituição de `ADMIN` por `MENTOR` e `USER` por `MENTORADO` em todo o sistema.

#### Ajuste na Lógica de Permissões:
- Modificação do método `getAuthorities()` na entidade `User` para garantir exclusividade entre os papéis.
- Agora, um `MENTOR` não herda mais permissões de `MENTORADO`.

#### Atualização do Frontend:
- Envio correto do papel selecionado ao backend.

---

### Arquivos Afetados

#### Backend
- `model/User.java`: Ajuste no método `getAuthorities()` para refletir as novas permissões exclusivas.  
  Caminho: `backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/model/User.java`

- `util/UserRole.java`: Renomeação do enum para `MENTOR` e `MENTORADO`.  
  Caminho: `backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/util/UserRole.java`

- `security/SecurityConfig.java`: Limpeza de comentários relacionados aos papéis antigos.  
  Caminho: `backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/security/SecurityConfig.java`

#### Frontend
- `register.component.html`: Atualização das opções no campo de seleção de papéis.  
  Caminho: `frontend/src/app/auth/register/register.component.html`

---

### Issues Relacionadas
- Refere-se a #9 
