### PR TITLE
[chore][backend]: configurar CORS para permitir acesso do frontend

### DIFF
--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/util/CorsConfig.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/util/CorsConfig.java
@@ -1,0 +1,21 @@
+package br.edu.ufape.plataforma.mentoria.util;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:4200") // Permite Angular acessar
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Descrição

<!-- Explique de forma objetiva o que foi feito neste PR e o motivo da mudança. -->

Configura CORS para permitir que o frontend Angular (em `http://localhost:4200`) acesse a API backend durante o desenvolvimento.  Foi criada a classe `CorsConfig`, anotada com `@Configuration`, que libera todos os endpoints para esse origin.
Essa configuração corrige o erro de CORS que estava impedindo chamadas HTTP do frontend.

---

## Correções

<!-- Liste os problemas corrigidos, de forma objetiva (ou diga N/A) -->
- Corrige erro de CORS que impedia o frontend de se comunicar com o backend

---

## Melhorias

<!-- Liste melhorias, refatorações ou ajustes menores (ou diga N/A) -->
- Adiciona classe de configuração `CorsConfig` com liberação controlada para o frontend

---

## Tipo de mudança

- [x] Correção de bug (mudança que não quebra nada e corrige um problema)
- [ ] Nova funcionalidade (mudança que não quebra nada e adiciona funcionalidade)
- [ ] Requer uma atualização na documentação
- [ ] Contém `migrate`
- [ ] Adição de novas dependências
- [x] Alteração da configuração de ambiente local (ex: .env, Docker, scripts)
- [x] Melhoria interna/refatoração

---

## Relevância

- [ ] Alta: bloqueia deploys, corrige falhas graves ou impede o uso da aplicação
- [x] Média: corrige comportamentos incorretos, melhora a usabilidade ou a segurança
- [ ] Baixa: ajustes visuais, pequenas melhorias internas ou refatorações sem impacto direto

---

## Issues relacionadas

<!-- Use `Closes #XX` se o PR resolve completamente a issue e ela deve ser fechada quando o PR for mergeado. -->
<!-- Use `Refers to #YY` se o PR apenas se relaciona à issue (ex: complementa, discute, mas não resolve). -->

- Closes #76   