### PR TITLE
[fix][security]: Corrige visualização do H2 Console

### DIFF
--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/security/SecurityConfig.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/security/SecurityConfig.java
@@ -23,6 +23,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity.csrf(csrf -> csrf.disable())
+            .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()))
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authorize -> authorize
             .anyRequest().permitAll()


### PR DESCRIPTION
## Descrição

A configuração padrão do Spring Security bloqueia a renderização de iframes (X-Frame-Options: DENY), o que impedia o funcionamento do H2 Console.

Esta alteração ajusta a política de frameOptions para 'sameOrigin', permitindo que o console seja exibido corretamente durante o desenvolvimento.

---

## Correções

- Corrige bloqueio da visualização do H2 no navegador

---

## Melhorias

- N/A

---

## Tipo de mudança

- [x] Correção de bug (mudança que não quebra nada e corrige um problema)
- [ ] Nova funcionalidade (mudança que não quebra nada e adiciona funcionalidade)
- [ ] Requer uma atualização na documentação
- [ ] Contém `migrate`
- [ ] Adição de novas dependências
- [ ] Alteração da configuração de ambiente local (ex: .env, Docker, scripts)
- [ ] Melhoria interna/refatoração

---

## Relevância

- [ ] Alta: bloqueia deploys, corrige falhas graves ou impede o uso da aplicação
- [x] Média: corrige comportamentos incorretos, melhora a usabilidade ou a segurança
- [ ] Baixa: ajustes visuais, pequenas melhorias internas ou refatorações sem impacto direto

---

## Issues relacionadas

- N/A