### PR TITLE
[feat][backend]: T10 - Criar um controller para mentorado

### DIFF
--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/controller/MentoredController.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/controller/MentoredController.java
@@ -1,0 +1,48 @@
+package br.edu.ufape.plataforma.mentoria.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import lombok.RequiredArgsConstructor;
+
+import br.edu.ufape.plataforma.mentoria.dto.MentoredDTO;
+import br.edu.ufape.plataforma.mentoria.service.MentoredService;
+
+@RestController
+@RequestMapping("/api/mentored")
+@RequiredArgsConstructor
+public class MentoredController {
+
+    private final MentoredService mentoredService;
+
+    @GetMapping
+    public ResponseEntity<List<MentoredDTO>> getAllMentoreds() {
+        List<MentoredDTO> mentoreds = mentoredService.findAllMentoreds();
+        return ResponseEntity.ok(mentoreds);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<MentoredDTO> getMentoredById(@PathVariable Long id) {
+        MentoredDTO mentored = mentoredService.findMentoredById(id);
+        return ResponseEntity.ok(mentored);
+    }
+
+    @PostMapping
+    public ResponseEntity<MentoredDTO> createMentored(@RequestBody MentoredDTO mentoredDTO) {
+        MentoredDTO savedMentored = mentoredService.saveMentored(mentoredDTO);
+        return ResponseEntity.ok(savedMentored);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<MentoredDTO> updateMentored(@PathVariable Long id, @RequestBody MentoredDTO mentoredDTO) {
+        MentoredDTO updatedMentored = mentoredService.updateMentored(id, mentoredDTO);
+        return ResponseEntity.ok(updatedMentored);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteMentored(@PathVariable Long id) {
+        mentoredService.deleteMentoredById(id);
+        return ResponseEntity.noContent().build();
+    }
+}


### PR DESCRIPTION
## Descrição

Este Pull Request introduz o `MentoredController`, estabelecendo a camada de API para o gerenciamento de mentorados. O objetivo é criar a interface de comunicação para as operações básicas de CRUD (Create, Read, Update, Delete).

Foram implementadas as seguintes rotas:
- `POST` para cadastro.
- `GET` para listagem.
- `PUT` para edição.
- `DELETE ` para exclusão.

A lógica de negócio e o acesso ao banco de dados foram abstraídos para o `MentoradoService`, que será implementado em uma tarefa futura.

---

## Correções

N/A

---

## Melhorias

N/A

---

## Tipo de mudança

- [ ] Correção de bug (mudança que não quebra nada e corrige um problema)
- [x] Nova funcionalidade (mudança que não quebra nada e adiciona funcionalidade)
- [ ] Requer uma atualização na documentação
- [ ] Contém `migrate`
- [ ] Adição de novas dependências
- [ ] Alteração da configuração de ambiente local (ex: .env, Docker, scripts)
- [ ] Melhoria interna/refatoração

---

## Relevância

- [ ] Alta: bloqueia deploys, corrige falhas graves ou impede o uso da aplicação
- [x] Média: corrige comportamentos incorretos, melhora a usabilidade ou a segurança
- [ ] Baixa: ajustes visuais, pequenas melhorias internas ou refatorações sem impacto direto

---

## Issues relacionadas

- Refers to T10