### PR TITLE
[feat][backend]: T10 - Criar um controller para mentorado, com correções

### DIFF
--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/controller/MentoredController.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/controller/MentoredController.java
@@ -1,0 +1,60 @@
+package br.edu.ufape.plataforma.mentoria.controller;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import br.edu.ufape.plataforma.mentoria.dto.MentoredDTO;
+import br.edu.ufape.plataforma.mentoria.mapper.MentoredMapper;
+import br.edu.ufape.plataforma.mentoria.model.Mentored;
+import br.edu.ufape.plataforma.mentoria.service.MentoredService;
+
+@RestController
+@RequestMapping("/api/mentored")
+public class MentoredController {
+
+    private final MentoredService mentoredService;
+    private final MentoredMapper mentoredMapper;
+
+    @Autowired
+    public MentoredController(MentoredService mentoredService, MentoredMapper mentoredMapper) {
+        this.mentoredService = mentoredService;
+        this.mentoredMapper = mentoredMapper;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<MentoredDTO>> getAllMentored() {
+        List<MentoredDTO> mentoreds = mentoredService.getAllMentored()
+                .stream()
+                .map(mentoredMapper::toDto)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(mentoreds);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<MentoredDTO> getMentoredById(@PathVariable Long id) throws Exception {
+        Mentored mentored = mentoredService.getMentoredById(id);
+        return ResponseEntity.ok(mentoredMapper.toDto(mentored));
+    }
+
+    @PostMapping
+    public ResponseEntity<MentoredDTO> createMentored(@RequestBody MentoredDTO mentoredDTO) {
+        Mentored savedMentored = mentoredService.createMentored(mentoredDTO);
+        return ResponseEntity.ok(mentoredMapper.toDto(savedMentored));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<MentoredDTO> updateMentored(@PathVariable Long id, @RequestBody MentoredDTO mentoredDTO) throws Exception {
+        Mentored updatedMentored = mentoredService.updateMentored(id, mentoredDTO);
+        return ResponseEntity.ok(mentoredMapper.toDto(updatedMentored));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteMentored(@PathVariable Long id) throws Exception {
+        mentoredService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}


### PR DESCRIPTION
## Descrição

Este Pull Request introduz o `MentoredController`, estabelecendo a camada de API para o gerenciamento de mentorados. O objetivo é criar a interface de comunicação para as operações básicas de CRUD (Create, Read, Update, Delete).

Foram implementadas as seguintes rotas:
- `POST` para cadastro.
- `GET` para listagem.
- `PUT` para edição.
- `DELETE ` para exclusão.

A lógica de negócio e o acesso ao banco de dados foram abstraídos para o `MentoradoService`, que será implementado em uma tarefa futura.

---

## Correções

N/A

---

## Melhorias

N/A

---

## Tipo de mudança

- [ ] Correção de bug (mudança que não quebra nada e corrige um problema)
- [x] Nova funcionalidade (mudança que não quebra nada e adiciona funcionalidade)
- [ ] Requer uma atualização na documentação
- [ ] Contém `migrate`
- [ ] Adição de novas dependências
- [ ] Alteração da configuração de ambiente local (ex: .env, Docker, scripts)
- [ ] Melhoria interna/refatoração

---

## Relevância

- [ ] Alta: bloqueia deploys, corrige falhas graves ou impede o uso da aplicação
- [x] Média: corrige comportamentos incorretos, melhora a usabilidade ou a segurança
- [ ] Baixa: ajustes visuais, pequenas melhorias internas ou refatorações sem impacto direto

---

## Issues relacionadas

- Refers to T10