### PR TITLE
[fix][backend]: Corrige update de perfis mentor e mentorado no service

### DIFF
--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/controller/MentoredController.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/controller/MentoredController.java
@@ -1,52 +1,33 @@
 package br.edu.ufape.plataforma.mentoria.controller;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import br.edu.ufape.plataforma.mentoria.exceptions.EntityNotFoundException;
-import br.edu.ufape.plataforma.mentoria.model.Mentored;
-import br.edu.ufape.plataforma.mentoria.service.MentorService;
-import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import br.edu.ufape.plataforma.mentoria.dto.MentoredDTO;
+import br.edu.ufape.plataforma.mentoria.exceptions.EntityNotFoundException;
 import br.edu.ufape.plataforma.mentoria.mapper.MentoredMapper;
 import br.edu.ufape.plataforma.mentoria.service.MentoredService;
+import br.edu.ufape.plataforma.mentoria.service.MentoredService;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/mentored")
 public class MentoredController {
 
-    private final MentoredService mentoredService;
-    private final MentoredMapper mentoredMapper;
-    private final MentorService mentorService;
+    @Autowired
+    private MentoredService mentoredService;
 
     @Autowired
-    public MentoredController(MentoredService mentoredService, MentoredMapper mentoredMapper, MentorService mentorService) {
-        this.mentoredService = mentoredService;
-        this.mentoredMapper = mentoredMapper;
-        this.mentorService = mentorService;
-    }
-
-    @GetMapping
-    public ResponseEntity<List<MentoredDTO>> getAllMentored() {
-        List<MentoredDTO> mentoreds = mentoredService.getAllMentored()
-                .stream()
-                .map(mentoredMapper::toDto)
-                .collect(Collectors.toList());
-        return ResponseEntity.ok(mentoreds);
-    }
+    private MentoredMapper mentoredMapper;
 
     @GetMapping("/{idMentored}")
-
-    public ResponseEntity<MentoredDTO> getMentoredById(@PathVariable Long idMentored) throws Exception {
-        Mentored mentoredDTO = mentoredService.getMentoredById(idMentored);
+    public ResponseEntity<MentoredDTO> getMentoredDetails(@PathVariable Long idMentored) throws Exception {
+        MentoredDTO mentoredDTO = mentoredService.getMentoredDetailsDTO(idMentored);
         if (mentoredDTO == null) {
             return ResponseEntity.notFound().build();
         }
-        return ResponseEntity.ok(mentoredMapper.toDto(mentoredDTO));
-
+        return ResponseEntity.ok(mentoredDTO);
     }
 
     @PostMapping
@@ -56,31 +37,45 @@ public class MentoredController {
     }
 
     @PutMapping("/{idMentored}")
-    public ResponseEntity<MentoredDTO> updateMentored(@PathVariable Long id, @RequestBody MentoredDTO mentoredDTO) throws Exception {
-        MentoredDTO updatedMentored = mentoredService.updateMentored(id, mentoredDTO);
-        if (updatedMentored == null) {
+    public ResponseEntity<MentoredDTO> updateMentored(@PathVariable Long idMentored,
+            @Valid @RequestBody MentoredDTO mentoredDTO) throws Exception {
+        MentoredDTO updatedMentoredDTO = mentoredService.updateMentored(idMentored, mentoredDTO);
+        if (updatedMentoredDTO == null) {
             return ResponseEntity.notFound().build();
         }
-        return ResponseEntity.ok(updatedMentored);
+        return ResponseEntity.ok(updatedMentoredDTO);
     }
 
     @DeleteMapping("/{idMentored}")
-    public ResponseEntity<Void> deleteMentored(@PathVariable Long idMentored) throws Exception {
-        mentoredService.deleteById(idMentored);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<String> deleteMentored(@PathVariable Long idMentored) throws Exception {
+        try {
+            mentoredService.deleteById(idMentored);
+            return ResponseEntity.ok("Mentored(a) removido(a) com sucesso!");
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
     }
 
-//    @GetMapping("/mentors/search")
-//    public ResponseEntity<List<MentorDTO>> searchMentor(
-//            @RequestParam(required = false) InterestArea interestArea,
-//            @RequestParam(required = false) List<String> specializations) {
+//    @GetMapping("/search")
+//    public ResponseEntity<List<MentoredDTO>> searchMentored(
+//            @RequestParam(required = false) String fullName,
+//            @RequestParam(required = false) InterestArea interestArea) {
 //
-//        if (interestArea == null && (specializations == null || specializations.isEmpty())) {
+//        if (fullName == null && interestArea == null) {
 //            return ResponseEntity.ok(Collections.emptyList());
 //        }
 //
-//        List<MentorDTO> results = mentorService.findMentors(interestArea, specializations);
+//        List<MentoredDTO> results = mentoredService.findByNameAndInterestArea(fullName, interestArea);
 //        return ResponseEntity.ok(results);
+//    }
+
+//    @GetMapping("/interests/mentored/{interestName}")
+//    public ResponseEntity<List<MentorededDTO>> searchMentorededByInterest(@PathVariable String interestName) {
+//        List<Mentoreded> results = mentoredService.searchMentoredByInterest(interestName);
+//        List<MentoredDTO> resultsDTO = results.stream()
+//                .map(mentoredMapper::toDto)
+//                .toList();
+//        return ResponseEntity.ok(resultsDTO);
 //    }
 
     @GetMapping("/me")

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/mapper/MentoredMapper.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/mapper/MentoredMapper.java
@@ -18,7 +18,7 @@ public class MentoredMapper {
         return mentored;
     }
 
-    public MentoredDTO toDto(Mentored mentored) {
+    public MentoredDTO toDTO(Mentored mentored) {
         MentoredDTO mentoredDTO = new MentoredDTO();
         mentoredDTO.setId(mentored.getId());
         mentoredDTO.setFullName(mentored.getFullName());

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/MentorService.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/MentorService.java
@@ -74,16 +74,21 @@ public class MentorService {
     }
 
     public MentorDTO updateMentor(Long id, MentorDTO mentorDTO) throws Exception {
-        if (mentorRepository.existsById(id)) {
-            Mentor mentor = mentorMapper.toEntity(mentorDTO);
-            mentor.setId(id);
-            User user = userRepository.findById(mentor.getUser().getId())
-                    .orElseThrow(() -> new RuntimeException("Usuário não encontrado: " + mentor.getUser().getId()));
-            mentor.setUser(user);
-            Mentor updatedMentor = mentorRepository.save(mentor);
-            return mentorMapper.toDTO(updatedMentor);
-        }
-        throw new EntityNotFoundException(Mentor.class, id);
+        // Buscar o mentor existente para obter o User
+        Mentor existingMentor = mentorRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Mentor.class, id));
+        
+        // Converter DTO para Entity
+        Mentor mentorToUpdate = mentorMapper.toEntity(mentorDTO);
+        
+        // Definir o ID e o User existente
+        mentorToUpdate.setId(id);
+        mentorToUpdate.setUser(existingMentor.getUser());
+        
+        // Salvar o mentor atualizado
+        Mentor updatedMentor = mentorRepository.save(mentorToUpdate);
+        
+        return mentorMapper.toDTO(updatedMentor);
     }
 
     public void deleteById(Long id) throws Exception {

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/MentoredService.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/MentoredService.java
@@ -7,6 +7,7 @@ import br.edu.ufape.plataforma.mentoria.model.User;
 import br.edu.ufape.plataforma.mentoria.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import br.edu.ufape.plataforma.mentoria.dto.MentorDTO;
 import br.edu.ufape.plataforma.mentoria.dto.MentoredDTO;
 import br.edu.ufape.plataforma.mentoria.exceptions.AttributeAlreadyInUseException;
 import br.edu.ufape.plataforma.mentoria.mapper.MentoredMapper;
@@ -36,7 +37,7 @@ public class MentoredService {
 
     public MentoredDTO getMentoredDetailsDTO(Long id) throws Exception {
         Mentored mentored = getMentoredById(id);
-        return mentoredMapper.toDto(mentored);
+        return mentoredMapper.toDTO(mentored);
     }
 
     public List<Mentored> getAllMentored() {
@@ -62,7 +63,7 @@ public class MentoredService {
 
         mentored.setUser(user);
         Mentored savedMentored = mentoredRepository.save(mentored); // Salva o objeto já configurado
-        return mentoredMapper.toDto(savedMentored);
+        return mentoredMapper.toDTO(savedMentored);
     }
 
     public Mentored updateMentored(Long id, Mentored mentored) throws Exception {
@@ -74,16 +75,17 @@ public class MentoredService {
     }
 
     public MentoredDTO updateMentored(Long id, MentoredDTO mentoredDTO) throws Exception {
-        if (mentoredRepository.existsById(id)) {
-            Mentored mentored = mentoredMapper.toEntity(mentoredDTO);
-            mentored.setId(id);
-            User user = userRepository.findById(mentored.getUser().getId())
-                    .orElseThrow(() -> new RuntimeException("Usuário não encontrado: " + mentored.getUser().getId()));
-            mentored.setUser(user);
-            Mentored updatedMentored = mentoredRepository.save(mentored);
-            return mentoredMapper.toDto(updatedMentored);
-        }
-        throw new EntityNotFoundException(Mentor.class, id);
+        Mentored existingMentored = mentoredRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Mentored.class, id));
+        
+        Mentored mentoredToUpdate = mentoredMapper.toEntity(mentoredDTO);
+        
+        mentoredToUpdate.setId(id);
+        mentoredToUpdate.setUser(existingMentored.getUser());
+        
+        Mentored updatedMentored = mentoredRepository.save(mentoredToUpdate);
+        
+        return mentoredMapper.toDTO(updatedMentored);
     }
 
     public void deleteById(Long id) throws Exception {
@@ -98,7 +100,7 @@ public class MentoredService {
         String email = auth.getName();
 
         return mentoredRepository.findByUserEmail(email)
-                .map(mentoredMapper::toDto)
+                .map(mentoredMapper::toDTO)
                 .orElseThrow(() -> new EntityNotFoundException(Mentored.class, email));
     }
 

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -139,6 +139,33 @@ export class AuthService {
     }
   }
 
+    async updateMentored(id: number, mentored: Mentored): Promise<Mentored | null> {
+    try {
+      const response = await fetch(`${this.apiUrlMentored}/${id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${this.getToken()}`,
+        },
+        body: JSON.stringify(mentored),
+      });
+
+      if (!response.ok) {
+        const errorData = await response
+          .json()
+          .catch(() => ({ message: 'Erro desconhecido' }));
+        const error = new Error(errorData.message || 'Atualização falhou');
+        (error as any).status = response.status;
+        throw error;
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.error('Erro ao atualizar Mentored no AuthService:', error);
+      throw error;
+    }
+  }
+
   async getCurrentMentor(): Promise<Mentor | null> {
     try {
       console.log('Buscando mentor atual...');

--- a/frontend/src/app/profile/profile.service.ts
+++ b/frontend/src/app/profile/profile.service.ts
@@ -66,13 +66,15 @@ export class ProfileService {
    return this.http.put(`${this.apiUrl}/mentor/${idMentor}`, data, { headers });
  }
 
-  updateMentoredProfile(data: any): Observable<any> {
-    return this.http.get(`${this.apiUrl}/mentored/me`).pipe(
-      switchMap((currentMentored: any) => {
-        return this.http.put(`${this.apiUrl}/mentored/${currentMentored.id}`, data);
-      })
-    );
-  }
+updateMentoredProfile(data: any): Observable<any> {
+  const token = localStorage.getItem('token');
+  const headers = { Authorization: `Bearer ${token}` };
+  return this.http.get(`${this.apiUrl}/mentored/me`, { headers }).pipe(
+    switchMap((currentMentored: any) => {
+      return this.http.put(`${this.apiUrl}/mentored/${currentMentored.id}`, data, { headers });
+    })
+  );
+}
 
   getCurrentProfileType(): string {
     return this.profileTypeSubject.value;


### PR DESCRIPTION
## Descrição
Corrige problemas no update de perfis de mentor e mentorado que estavam falhando devido à lógica incorreta de preservação do usuário associado no service layer. Também padroniza a estrutura dos controllers removendo imports desnecessários.

---
## Correções
- Corrige método `updateMentor` no MentorService para preservar usuário existente ao invés de tentar buscar por ID incorreto
- Corrige método `updateMentored` no MentoredService com a mesma lógica
- Resolve falha de validação no update que estava causando erro de `interestArea` null

---
## Melhorias
- Padroniza estrutura dos controllers MentorController e MentoredController
- Remove imports desnecessários e duplicados
- Melhora tratamento de erros nos services de update

---
## Tipo de mudança
- [x] Correção de bug (mudança que não quebra nada e corrige um problema)
- [ ] Nova funcionalidade (mudança que não quebra nada e adiciona funcionalidade)
- [ ] Requer uma atualização na documentação
- [ ] Contém `migrate`
- [ ] Adição de novas dependências
- [ ] Alteração da configuração de ambiente local (ex: .env, Docker, scripts)
- [x] Melhoria interna/refatoração

---
## Relevância
- [ ] Alta: bloqueia deploys, corrige falhas graves ou impede o uso da aplicação
- [x] Média: corrige comportamentos incorretos, melhora a usabilidade ou a segurança
- [ ] Baixa: ajustes visuais, pequenas melhorias internas ou refatorações sem impacto direto

---
## Issues relacionadas
- Closes #177, #180 
-  Refers to #176, #173, #178 
