### PR TITLE
[feature][backend] T11 - Criar componente de visualização do histórico de sessões

### DIFF
--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/security/TokenService.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/security/TokenService.java
@@ -25,6 +25,7 @@ public class TokenService {
                 .withIssuer("Mentoria")
                 .withSubject(user.getUsername())
                 .withClaim("role", user.getRole().name())
+                .withClaim("userId", user.getId())
                 .withExpiresAt(this.getExpirationAt())
                 .sign(algorithm);
             return token;

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -1,5 +1,3 @@
-
-// src/app/app.routes.ts
 import { Routes } from '@angular/router';
 
 import { LoginComponent } from './auth/login/login.component';
@@ -9,6 +7,7 @@ import { ProfileService, ProfileData } from '../app/profile/profile.service';
 import { UnauthorizedComponent } from './auth/unauthorized/unauthorized';
 import { HomeComponent } from './home/home.component';
 import { authGuard } from './auth/auth-guard';
+import { SessionHistoryComponent } from './session-history/session-history.component';
 import { MentorRegisterComponent } from './auth/register/mentor-register/mentor-register/mentor-register.component';
 import { MentoredRegisterComponent } from './auth/register/mentored-register/mentored-register/mentored-register.component';
 import { SessionComponent } from './sessions/session.component';
@@ -22,7 +21,8 @@ export const routes: Routes = [
   { path: 'register-mentored', component: MentoredRegisterComponent, title: 'Finalizar Cadastro' },
   { path: 'profile', component: ProfileComponent,  title: 'Perfil' },
   { path: 'home', component: HomeComponent, title: 'Plataforma de Mentoria', canActivate: [authGuard] },
-  { path: 'sessions', component: SessionComponent , title: 'Sessões', canActivate: [authGuard]}, 
+  { path: 'sessions', component: SessionComponent , title: 'Sessões', canActivate: [authGuard]},
+  { path: 'sessions/history', component: SessionHistoryComponent, title: 'Histórico de Sessões', canActivate: [authGuard] },
   { path: 'unauthorized', component: UnauthorizedComponent, title: 'Não autorizado' },
 
   { path: '**', redirectTo: 'login' }

--- a/frontend/src/app/home/home.component.css
+++ b/frontend/src/app/home/home.component.css
@@ -181,3 +181,17 @@ body, .main {
   height: 32px;
   display: block;
 }
+.history-button {
+  background: #3b6be8;
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 0.6rem 1.2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  margin-left: 1.5rem;
+  margin-top: 1.5rem;
+  box-shadow: 0 2px 8px rgba(59, 107, 232, 0.08);
+  transition: background 0.2s, box-shadow 0.2s;
+}

--- a/frontend/src/app/home/home.component.html
+++ b/frontend/src/app/home/home.component.html
@@ -3,6 +3,9 @@
     <button class="logout" (click)="logout()" *ngIf="isAuthenticated()">
       Logout
     </button>
+    <button class="history-button" (click)="navigateToHistory()" title="Ver Histórico">
+      <span>Histórico de Sessões</span>
+    </button>
     <button class="logout" (click)="session()" *ngIf="isAuthenticated()">
       Marcar Sessão
     </button>

--- a/frontend/src/app/home/home.component.ts
+++ b/frontend/src/app/home/home.component.ts
@@ -30,6 +30,9 @@ export class HomeComponent implements OnInit, OnDestroy {
 
 
   }
+  navigateToHistory(): void {
+    this.router.navigate(['/sessions/history']);
+  }
 
   logout() {
     this.authService.logout();

--- a/frontend/src/app/session-history/session-history.component.css
+++ b/frontend/src/app/session-history/session-history.component.css
@@ -1,0 +1,154 @@
+.history-container {
+  max-width: 900px;
+  margin: 2rem auto;
+  padding: 2rem;
+  font-family: 'Segoe UI', sans-serif;
+  background-color: #f8f9fa;
+  border-radius: 16px;
+}
+
+.history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #dee2e6;
+}
+
+.history-header h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #2a3b6e;
+}
+
+.back-button {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background-color: #3b6be8;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 0.6rem 1.2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s, box-shadow 0.2s;
+}
+
+.back-button:hover {
+  background-color: #2a3b6e;
+  box-shadow: 0 4px 12px rgba(59, 107, 232, 0.2);
+}
+
+.back-button svg {
+  width: 20px;
+  height: 20px;
+}
+
+/* --- LISTA DE CARDS --- */
+.session-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.session-card {
+  background-color: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.07);
+  padding: 1.5rem;
+  border-left: 5px solid #3b6be8;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.session-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.session-topic {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #2a3b6e;
+}
+
+/* --- TAGS DE STATUS --- */
+.status-tag {
+  padding: 0.25rem 0.75rem;
+  border-radius: 16px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: white;
+}
+
+.status-pending { background-color: #f59e0b; } /* Amarelo */
+.status-accepted { background-color: #10b981; } /* Verde */
+.status-rejected { background-color: #ef4444; } /* Vermelho */
+.status-completed { background-color: #3b82f6; } /* Azul */
+.status-cancelled { background-color: #6b7280; } /* Cinza */
+
+/* --- DETALHES DA SESSÃO --- */
+.card-body {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.session-detail {
+  display: flex;
+  flex-direction: column;
+}
+
+.detail-label {
+  font-size: 0.85rem;
+  color: #6c757d;
+  margin-bottom: 0.25rem;
+}
+
+.detail-value {
+  font-size: 1rem;
+  font-weight: 500;
+  color: #343a40;
+}
+
+/* --- BOTÕES DE AÇÃO --- */
+.card-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.action-button {
+  border: none;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.action-button:hover {
+  opacity: 0.85;
+}
+
+.action-button.accept { background-color: #10b981; color: white; }
+.action-button.reject { background-color: #ef4444; color: white; }
+.action-button.complete { background-color: #3b82f6; color: white; }
+.action-button.cancel { background-color: #6b7280; color: white; }
+
+.no-sessions {
+  text-align: center;
+  padding: 2rem;
+  color: #6c757d;
+}

--- a/frontend/src/app/session-history/session-history.component.html
+++ b/frontend/src/app/session-history/session-history.component.html
@@ -1,0 +1,38 @@
+<div class="history-container">
+  <header class="history-header">
+    <h1>Histórico de Sessões</h1>
+    <button class="back-button" (click)="goBack()">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+      </svg>
+      Voltar
+    </button>
+  </header>
+
+  <div class="session-list">
+    <div class="session-card" *ngFor="let session of sessions">
+      <div class="card-header">
+        <span class="session-topic">{{ session.meetingTopic }}</span>
+        <span class="status-tag" [ngClass]="getStatusClass(session.status)">{{ session.status }}</span>
+      </div>
+      <div class="card-body">
+        <div class="session-detail">
+          <span class="detail-label">Data:</span>
+          <span class="detail-value">{{ session.date | date: 'dd/MM/yyyy' }}</span>
+        </div>
+        <div class="session-detail">
+          <span class="detail-label">Hora:</span>
+          <span class="detail-value">{{ session.time }}</span>
+        </div>
+        <div class="session-detail">
+          <span class="detail-label">Local:</span>
+          <span class="detail-value">{{ session.location }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="no-sessions" *ngIf="sessions.length === 0">
+      <p>Nenhuma sessão encontrada no seu histórico.</p>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/session-history/session-history.component.spec.ts
+++ b/frontend/src/app/session-history/session-history.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SessionHistory } from './session-history';
+
+describe('SessionHistory', () => {
+  let component: SessionHistory;
+  let fixture: ComponentFixture<SessionHistory>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SessionHistory]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SessionHistory);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/session-history/session-history.component.ts
+++ b/frontend/src/app/session-history/session-history.component.ts
@@ -1,0 +1,42 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule, DatePipe } from '@angular/common';
+import { Router } from '@angular/router';
+import { ProfileService } from '../profile/profile.service';
+
+@Component({
+  selector: 'app-session-history',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './session-history.component.html',
+  styleUrls: ['./session-history.component.css'],
+  providers: [DatePipe]
+})
+export class SessionHistoryComponent implements OnInit {
+  sessions: any[] = [];
+
+  private profileService = inject(ProfileService);
+  private router = inject(Router);
+
+  ngOnInit(): void {
+    this.loadSessionHistory();
+  }
+
+  loadSessionHistory(): void {
+    this.profileService.getSessionHistory().subscribe({
+      next: (data) => {
+        this.sessions = data;
+      },
+      error: (err) => {
+        console.error('Erro ao carregar histórico de sessões:', err);
+      }
+    });
+  }
+
+  getStatusClass(status: string): string {
+    return 'status-' + status.toLowerCase();
+  }
+
+  goBack(): void {
+    this.router.navigate(['/home']);
+  }
+}


### PR DESCRIPTION
## Descrição

Este PR adiciona a tela de Histórico de Sessões,  (com status como PENDING ou ACCEPTED). O problema era causado por um filtro no frontend que mostrava apenas sessões com status finalizados (COMPLETED, CANCELLED, etc.).
A lógica foi ajustada para exibir todas as sessões retornadas pela API, garantindo que o usuário tenha visibilidade completa do seu histórico, incluindo agendamentos pendentes ou confirmados.

---

## Correções

<!-- Liste os problemas corrigidos, de forma objetiva (ou diga N/A) -->
- Corrige [...]

---

## Melhorias

N/A
---

## Tipo de mudança

- [ ] Correção de bug (mudança que não quebra nada e corrige um problema)
- [X] Nova funcionalidade (mudança que não quebra nada e adiciona funcionalidade)
- [ ] Requer uma atualização na documentação
- [ ] Contém `migrate`
- [ ] Adição de novas dependências
- [ ] Alteração da configuração de ambiente local (ex: .env, Docker, scripts)
- [ ] Melhoria interna/refatoração

---

## Relevância

- [ ] Alta: bloqueia deploys, corrige falhas graves ou impede o uso da aplicação
- [X] Média: corrige comportamentos incorretos, melhora a usabilidade ou a segurança
- [ ] Baixa: ajustes visuais, pequenas melhorias internas ou refatorações sem impacto direto

---

## Issues relacionadas
- Refers to #192