### PR TITLE
[test][backend]: adicionar testes unitários para MentoredSearchService

### DIFF
--- a/backend/plataforma.mentoria/src/test/java/br/edu/ufape/plataforma/mentoria/service/MentoredSearchServiceTest.java
+++ b/backend/plataforma.mentoria/src/test/java/br/edu/ufape/plataforma/mentoria/service/MentoredSearchServiceTest.java
@@ -4,6 +4,7 @@ import br.edu.ufape.plataforma.mentoria.dto.MentoredDTO;
 import br.edu.ufape.plataforma.mentoria.enums.Course;
 import br.edu.ufape.plataforma.mentoria.enums.InterestArea;
 import br.edu.ufape.plataforma.mentoria.enums.UserRole;
+import br.edu.ufape.plataforma.mentoria.exceptions.EntityNotFoundException;
 import br.edu.ufape.plataforma.mentoria.mapper.MentoredMapper;
 import br.edu.ufape.plataforma.mentoria.model.Mentored;
 import br.edu.ufape.plataforma.mentoria.model.User;
@@ -76,6 +77,20 @@ class MentoredSearchServiceTest {
     }
 
     @Test
+    void testGetCurrentMentored_NotFound() {
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(securityContext);
+
+        String userEmail = "notfound@gmail.com";
+        when(authentication.getName()).thenReturn(userEmail);
+        when(mentoredRepository.findByUserEmail(userEmail)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () -> {
+            mentoredSearchService.getCurrentMentored();
+        });
+    }
+
+    @Test
     void findByInterestArea() {
         InterestArea areaDeInteresse = InterestArea.CIBERSEGURANCA;
         List<Mentored> mentoredList = List.of(mentored);
@@ -100,6 +115,16 @@ class MentoredSearchServiceTest {
 
         assertNotNull(foundMentored);
         assertEquals(mentoredId, foundMentored.getId());
+    }
+
+    @Test
+    void getMentoredById_NotFound() {
+        Long mentoredId = 2L;
+        when(mentoredRepository.findById(mentoredId)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () -> {
+            mentoredSearchService.getMentoredById(mentoredId);
+        });
     }
 
     @Test


### PR DESCRIPTION
## Descrição

<!-- Explique de forma objetiva o que foi feito neste PR e o motivo da mudança. -->
---
- Implementação completa de testes unitários para a classe `MentoredSearchService`
- Os testes cobrem todos os algoritmos de busca, funcionalidades de filtro e critérios de validação conforme especificado na issue.

<img width="993" height="245" alt="image" src="https://github.com/user-attachments/assets/19f7217e-b83e-4d14-8a0b-7b9ed3cb25db" />

## Correções

<!-- Liste os problemas corrigidos, de forma objetiva (ou diga N/A) -->
- N/A

---

## Melhorias

<!-- Liste melhorias, refatorações ou ajustes menores (ou diga N/A) -->
- Adicionada cobertura completa de testes unitários para `MentoredSearchService `(100% na classe)
- Implementados testes para todos os algoritmos de busca (`getCurrentMentored`, `getMentoredById`, `getMentoredDetailsDTO`)
- Adicionados testes para funcionalidades de filtro (`findByInterestArea`)
- Criados testes de validação para critérios de pesquisa (parâmetros nulos, vazios e casos extremos)
- Utilizadas melhores práticas com Mockito para isolamento adequado dos testes unitários


---

## Tipo de mudança

- [ ] Correção de bug (mudança que não quebra nada e corrige um problema)
- [ ] Nova funcionalidade (mudança que não quebra nada e adiciona funcionalidade)
- [ ] Requer uma atualização na documentação
- [ ] Contém `migrate`
- [ ] Adição de novas dependências
- [ ] Alteração da configuração de ambiente local (ex: .env, Docker, scripts)
- [x] Melhoria interna/refatoração

---

## Relevância

- [ ] Alta: bloqueia deploys, corrige falhas graves ou impede o uso da aplicação
- [ ] Média: corrige comportamentos incorretos, melhora a usabilidade ou a segurança
- [x] Baixa: ajustes visuais, pequenas melhorias internas ou refatorações sem impacto direto

---

## Issues relacionadas

<!-- Use `Closes #XX` se o PR resolve completamente a issue e ela deve ser fechada quando o PR for mergeado. -->
<!-- Use `Refers to #YY` se o PR apenas se relaciona à issue (ex: complementa, discute, mas não resolve). -->

- Closes #241   