### PR TITLE
[adjs][backend]: T18 - Remover wrappers desnecessários de AssociationOverrides

### DIFF
--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/exceptions/EntityNotFoundException.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/exceptions/EntityNotFoundException.java
@@ -15,7 +15,7 @@ public class EntityNotFoundException extends RuntimeException {
      * @param entityId    The identifier of the entity that was not found.
      */
     public EntityNotFoundException(Class<?> entityClass, Object entityId) {
-        super(String.format("%s with ID %s not found.", entityClass.getSimpleName(), entityId.toString()));
+        super(String.format("%s com ID %s não foi encontrado.", entityClass.getSimpleName(), entityId.toString()));
     }
 
     /**
@@ -27,7 +27,8 @@ public class EntityNotFoundException extends RuntimeException {
      * @param resourceValue The value of the resource that was not found.
      */
     public EntityNotFoundException(Class<?> entityClass, String resourceName, String resourceValue) {
-        super(String.format("%s with %s '%s' not found.", entityClass.getSimpleName(), resourceName, resourceValue));
+        super(String.format("%s com %s '%s' não foi encontrado.", entityClass.getSimpleName(), resourceName,
+                resourceValue));
     }
 
     /**

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/MentorSearchService.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/MentorSearchService.java
@@ -19,7 +19,6 @@ import java.util.stream.Collectors;
 @Service
 public class MentorSearchService implements MentorSearchServiceInterface {
 
-
     @Autowired
     private MentorRepository mentorRepository;
 
@@ -34,6 +33,7 @@ public class MentorSearchService implements MentorSearchServiceInterface {
         return mentorRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(Mentor.class, id));
     }
+
     @Override
     public MentorDTO getMentorDetailsDTO(Long id) {
         Mentor mentor = this.getMentorById(id);
@@ -54,20 +54,13 @@ public class MentorSearchService implements MentorSearchServiceInterface {
                 .map(mentorMapper::toDTO)
                 .orElseThrow(() -> new EntityNotFoundException(Mentor.class, email));
     }
+
     @Override
     public List<MentorDTO> findByInterestAreaAndSpecializations(InterestArea interestArea, String specialization) {
-        List<Mentor> mentors = mentorRepository.findByInterestAreaAndSpecializationsContaining(interestArea, specialization);
+        List<Mentor> mentors = mentorRepository.findByInterestAreaAndSpecializationsContaining(interestArea,
+                specialization);
         return mentors.stream()
                 .map(mentorMapper::toDTO)
                 .collect(Collectors.toList());
     }
-
-
-
-
-
-
-
-
 }
-

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/SessionService.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/SessionService.java
@@ -39,19 +39,20 @@ public class SessionService implements SessionServiceInterface {
     @Override
     public Session getSessionById(Long id) {
         return sessionRepository.findById(id)
-                .orElseThrow(() ->  new EntityNotFoundException(Session.class, id));
+                .orElseThrow(() -> new EntityNotFoundException(Session.class, id));
     }
+
     @Override
     public Session createSession(SessionDTO sessionDTO) {
         sessionDTO.setStatus(Status.PENDING);
 
         Mentor mentor = mentorRepository.findById(sessionDTO.getMentorId())
-                .orElseThrow(() -> new EntityNotFoundException("Mentor com o ID " + sessionDTO.getMentorId() + " não encontrado."));
+                .orElseThrow(() -> new EntityNotFoundException(Mentor.class, sessionDTO.getMentorId()));
 
         Mentored mentored = mentoredRepository.findById(sessionDTO.getMentoredID())
-                .orElseThrow(() -> new EntityNotFoundException("Mentorado com o ID " + sessionDTO.getMentoredID() + " não encontrado."));
+                .orElseThrow(() -> new EntityNotFoundException(Mentored.class, sessionDTO.getMentoredID()));
 
-        if(mentor.getId().equals(mentored.getId())) {
+        if (mentor.getId().equals(mentored.getId())) {
             throw new IllegalArgumentException("Mentor e Mentorado não podem ser a mesma pessoa.");
         }
         Session session = sessionMapper.toEntity(sessionDTO);
@@ -60,6 +61,7 @@ public class SessionService implements SessionServiceInterface {
 
         return sessionRepository.save(session);
     }
+
     @Override
     public SessionDTO updateSession(Long id, SessionDTO sessionDTO) {
         Session existingSession = getSessionById(id);
@@ -73,16 +75,19 @@ public class SessionService implements SessionServiceInterface {
 
         return sessionMapper.toDTO(updatedSession);
     }
+
     @Override
     public void deleteSession(Long id) {
         Session session = getSessionById(id);
         sessionRepository.delete(session);
     }
+
     @Override
     public SessionDTO getSessionDTOById(Long id) {
         Session session = getSessionById(id);
         return sessionMapper.toDTO(session);
     }
+
     @Override
     public SessionDTO updateSessionStatus(Long id, Status newStatus) {
         Session session = getSessionById(id);
@@ -102,49 +107,48 @@ public class SessionService implements SessionServiceInterface {
             case REJECTED:
             case COMPLETED:
             case CANCELLED:
-                throw new IllegalArgumentException("A sessão já está em um estado final (" + currentStatus + ") e não pode ser alterada.");
+                throw new IllegalArgumentException(
+                        "A sessão já está em um estado final (" + currentStatus + ") e não pode ser alterada.");
         }
 
         session.setStatus(newStatus);
         Session updatedSession = sessionRepository.save(session);
         return sessionMapper.toDTO(updatedSession);
     }
+
     @Override
     public List<SessionDTO> findSessionHistoryBetweenUsers(Long mentorId, Long mentoredId) {
-        Mentor mentor = mentorRepository.findById(mentorId)
-                .orElseThrow(() -> new EntityNotFoundException("Mentor com o ID " + mentorId + " não encontrado."));
+        mentorRepository.findById(mentorId)
+                .orElseThrow(() -> new EntityNotFoundException(Mentor.class, mentorId));
 
-        Mentored mentored = mentoredRepository.findById(mentoredId)
-                .orElseThrow(() -> new EntityNotFoundException("Mentorado com o ID " + mentoredId + " não encontrado."));
+        mentoredRepository.findById(mentoredId)
+                .orElseThrow(() -> new EntityNotFoundException(Mentored.class, mentoredId));
 
         List<Session> sessions = sessionRepository.findByMentorIdAndMentoredId(mentorId, mentoredId);
 
-        return sessions.stream().
-                map(sessionMapper::toDTO).
-                collect(Collectors.toList());
+        return sessions.stream().map(sessionMapper::toDTO).collect(Collectors.toList());
     }
+
     @Override
     public List<SessionDTO> findSessionHistoryMentor(Long mentorId) {
-        Mentor mentor = mentorRepository.findById(mentorId)
-                .orElseThrow(() -> new EntityNotFoundException("Mentor com o ID " + mentorId + " não encontrado."));
+        mentorRepository.findById(mentorId)
+                .orElseThrow(() -> new EntityNotFoundException(Mentor.class, mentorId));
 
         List<Session> sessions = sessionRepository.findByMentorId(mentorId);
 
-        return sessions.stream().
-                map(sessionMapper::toDTO).
-                collect(Collectors.toList());
+        return sessions.stream().map(sessionMapper::toDTO).collect(Collectors.toList());
     }
+
     @Override
     public List<SessionDTO> findSessionHistoryMentored(Long mentoredId) {
-        Mentored mentored = mentoredRepository.findById(mentoredId)
-                .orElseThrow(() -> new EntityNotFoundException("Mentorado com o ID " + mentoredId + " não encontrado."));
+        mentoredRepository.findById(mentoredId)
+                .orElseThrow(() -> new EntityNotFoundException(Mentored.class, mentoredId));
 
         List<Session> sessions = sessionRepository.findByMentoredId(mentoredId);
 
-        return sessions.stream().
-                map(sessionMapper::toDTO).
-                collect(Collectors.toList());
+        return sessions.stream().map(sessionMapper::toDTO).collect(Collectors.toList());
     }
+
     @Override
     public List<SessionDTO> findAll() {
         return sessionRepository.findAll().stream()

--- a/backend/plataforma.mentoria/src/test/java/br/edu/ufape/plataforma/mentoria/service/MentorSearchServiceTest.java
+++ b/backend/plataforma.mentoria/src/test/java/br/edu/ufape/plataforma/mentoria/service/MentorSearchServiceTest.java
@@ -1,0 +1,118 @@
+package br.edu.ufape.plataforma.mentoria.service;
+
+import br.edu.ufape.plataforma.mentoria.dto.MentorDTO;
+import br.edu.ufape.plataforma.mentoria.enums.InterestArea;
+import br.edu.ufape.plataforma.mentoria.exceptions.EntityNotFoundException;
+import br.edu.ufape.plataforma.mentoria.mapper.MentorMapper;
+import br.edu.ufape.plataforma.mentoria.model.Mentor;
+import br.edu.ufape.plataforma.mentoria.repository.MentorRepository;
+import br.edu.ufape.plataforma.mentoria.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class MentorSearchServiceTest {
+
+    @InjectMocks
+    private MentorSearchService mentorSearchService;
+
+    @Mock
+    private MentorRepository mentorRepository;
+
+    @Mock
+    private MentorMapper mentorMapper;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetMentorByIdFound() {
+        Mentor mentor = new Mentor();
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        Mentor result = mentorSearchService.getMentorById(1L);
+        assertEquals(mentor, result);
+    }
+
+    @Test
+    void testGetMentorByIdNotFound() {
+        when(mentorRepository.findById(2L)).thenReturn(Optional.empty());
+        assertThrows(EntityNotFoundException.class, () -> mentorSearchService.getMentorById(2L));
+    }
+
+    @Test
+    void testGetMentorDetailsDTO() {
+        Mentor mentor = new Mentor();
+        MentorDTO dto = new MentorDTO();
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(mentorMapper.toDTO(mentor)).thenReturn(dto);
+        MentorDTO result = mentorSearchService.getMentorDetailsDTO(1L);
+        assertEquals(dto, result);
+    }
+
+    @Test
+    void testGetAllMentors() {
+        Mentor mentor1 = new Mentor();
+        Mentor mentor2 = new Mentor();
+        List<Mentor> mentors = Arrays.asList(mentor1, mentor2);
+        when(mentorRepository.findAll()).thenReturn(mentors);
+        List<Mentor> result = mentorSearchService.getAllMentors();
+        assertEquals(mentors, result);
+    }
+
+    @Test
+    void testGetCurrentMentorFound() {
+        Authentication auth = mock(Authentication.class);
+        when(auth.getName()).thenReturn("test@email.com");
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        Mentor mentor = new Mentor();
+        MentorDTO dto = new MentorDTO();
+        when(mentorRepository.findByUserEmail("test@email.com")).thenReturn(Optional.of(mentor));
+        when(mentorMapper.toDTO(mentor)).thenReturn(dto);
+
+        MentorDTO result = mentorSearchService.getCurrentMentor();
+        assertEquals(dto, result);
+    }
+
+    @Test
+    void testGetCurrentMentorNotFound() {
+        Authentication auth = mock(Authentication.class);
+        when(auth.getName()).thenReturn("notfound@email.com");
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        when(mentorRepository.findByUserEmail("notfound@email.com")).thenReturn(Optional.empty());
+        assertThrows(EntityNotFoundException.class, () -> mentorSearchService.getCurrentMentor());
+    }
+
+    @Test
+    void testFindByInterestAreaAndSpecializations() {
+        Mentor mentor1 = new Mentor();
+        Mentor mentor2 = new Mentor();
+        List<Mentor> mentors = Arrays.asList(mentor1, mentor2);
+        MentorDTO dto1 = new MentorDTO();
+        MentorDTO dto2 = new MentorDTO();
+
+        when(mentorRepository.findByInterestAreaAndSpecializationsContaining(InterestArea.CIBERSEGURANCA, "Java"))
+                .thenReturn(mentors);
+        when(mentorMapper.toDTO(mentor1)).thenReturn(dto1);
+        when(mentorMapper.toDTO(mentor2)).thenReturn(dto2);
+
+        List<MentorDTO> result = mentorSearchService.findByInterestAreaAndSpecializations(InterestArea.CIBERSEGURANCA,
+                "Java");
+        assertEquals(2, result.size());
+        assertTrue(result.contains(dto1));
+        assertTrue(result.contains(dto2));
+    }
+}


### PR DESCRIPTION
## Descrição

<!-- Explique de forma objetiva o que foi feito neste PR e o motivo da mudança. -->
- Este PR refatora as entidades Mentor e Mentored para simplificar as anotações JPA e alinhá-las com as boas práticas. O objetivo é remover código redundante, melhorar a legibilidade e a manutenibilidade das entidades.
---

## Correções

<!-- Liste os problemas corrigidos, de forma objetiva (ou diga N/A) -->
- N/A

---

## Melhorias

<!-- Liste melhorias, refatorações ou ajustes menores (ou diga N/A) -->
- Simplifica o mapeamento do relacionamento @OneToOne com a entidade User, utilizando @JoinColumn em vez de @PrimaryKeyJoinColumn.

- Remove o wrapper desnecessário @AssociationOverrides quando há apenas uma anotação @AssociationOverride.

- Adiciona FetchType.LAZY aos relacionamentos @OneToOne para otimizar a performance, evitando o carregamento desnecessário de dados.

- Remove anotações e construtores redundantes para limpar o código das entidades.

---

## Tipo de mudança

- [ ] Correção de bug (mudança que não quebra nada e corrige um problema)
- [ ] Nova funcionalidade (mudança que não quebra nada e adiciona funcionalidade)
- [ ] Requer uma atualização na documentação
- [ ] Contém `migrate`
- [ ] Adição de novas dependências
- [ ] Alteração da configuração de ambiente local (ex: .env, Docker, scripts)
- [X] Melhoria interna/refatoração

---

## Relevância

- [ ] Alta: bloqueia deploys, corrige falhas graves ou impede o uso da aplicação
- [ ] Média: corrige comportamentos incorretos, melhora a usabilidade ou a segurança
- [X] Baixa: ajustes visuais, pequenas melhorias internas ou refatorações sem impacto direto

---

## Issues relacionadas

<!-- Use `Closes #XX` se o PR resolve completamente a issue e ela deve ser fechada quando o PR for mergeado. -->
<!-- Use `Refers to #YY` se o PR apenas se relaciona à issue (ex: complementa, discute, mas não resolve). -->

- Closes #253  
