### PR TITLE
[refactor]: T13 - Remove injeção por campo e adota injeção por construtor

### DIFF
--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/controller/MentorController.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/controller/MentorController.java
@@ -5,7 +5,6 @@ import java.util.List;
 import br.edu.ufape.plataforma.mentoria.service.contract.MentorSearchServiceInterface;
 import br.edu.ufape.plataforma.mentoria.service.contract.MentorServiceInterface;
 import br.edu.ufape.plataforma.mentoria.service.contract.MentoredSearchServiceInterface;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -31,17 +30,22 @@ import jakarta.validation.Valid;
 @RequestMapping("/mentor")
 public class MentorController {
 
-    @Autowired
-    private MentorServiceInterface mentorService;
+    private final MentorServiceInterface mentorService;
+    private final MentoredSearchServiceInterface mentoredSearchService;
+    private final MentorSearchServiceInterface mentorSearchService;
+    private final MentorMapper mentorMapper;
 
-    @Autowired
-    private MentoredSearchServiceInterface mentoredSearchService;
-
-    @Autowired
-    private MentorSearchServiceInterface mentorSearchService;
-
-    @Autowired
-    private MentorMapper mentorMapper;
+    public MentorController(
+        MentorServiceInterface mentorService,
+        MentoredSearchServiceInterface mentoredSearchService,
+        MentorSearchServiceInterface mentorSearchService,
+        MentorMapper mentorMapper
+    ) {
+        this.mentorService = mentorService;
+        this.mentoredSearchService = mentoredSearchService;
+        this.mentorSearchService = mentorSearchService;
+        this.mentorMapper = mentorMapper;
+    }
 
     @GetMapping("/{idMentor}")
     public ResponseEntity<MentorDTO> getMentorDetails(@PathVariable Long idMentor) {

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/controller/MentoredController.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/controller/MentoredController.java
@@ -5,7 +5,6 @@ import java.util.List;
 import br.edu.ufape.plataforma.mentoria.service.contract.MentorSearchServiceInterface;
 import br.edu.ufape.plataforma.mentoria.service.contract.MentoredSearchServiceInterface;
 import br.edu.ufape.plataforma.mentoria.service.contract.MentoredServiceInterface;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -31,17 +30,21 @@ import jakarta.validation.Valid;
 @RequestMapping("/mentored")
 public class MentoredController {
 
-    @Autowired
-    private MentoredServiceInterface mentoredService;
+    private final MentoredServiceInterface mentoredService;
+    private final MentoredSearchServiceInterface mentoredSearchService;
+    private final MentorSearchServiceInterface mentorSearchService;
+    private final MentoredMapper mentoredMapper;
 
-    @Autowired
-    private MentoredSearchServiceInterface mentoredSearchService;
-    
-    @Autowired
-    MentorSearchServiceInterface mentorSearchService;
-
-    @Autowired
-    private MentoredMapper mentoredMapper;
+    public MentoredController(
+            MentoredServiceInterface mentoredService,
+            MentoredSearchServiceInterface mentoredSearchService,
+            MentorSearchServiceInterface mentorSearchService,
+            MentoredMapper mentoredMapper) {
+        this.mentoredService = mentoredService;
+        this.mentoredSearchService = mentoredSearchService;
+        this.mentorSearchService = mentorSearchService;
+        this.mentoredMapper = mentoredMapper;
+    }
 
     @GetMapping("/{idMentored}")
     public ResponseEntity<MentoredDTO> getMentoredDetails(@PathVariable Long idMentored) {

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/controller/SessionController.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/controller/SessionController.java
@@ -6,7 +6,6 @@ import br.edu.ufape.plataforma.mentoria.mapper.SessionMapper;
 import br.edu.ufape.plataforma.mentoria.model.Session;
 import br.edu.ufape.plataforma.mentoria.service.contract.SessionServiceInterface;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,11 +15,13 @@ import java.util.List;
 @RequestMapping("/sessions")
 public class SessionController {
 
-    @Autowired
-    private SessionServiceInterface sessionService;
+    private final SessionServiceInterface sessionService;
+    private final SessionMapper sessionMapper;
 
-    @Autowired
-    private SessionMapper sessionMapper;
+    public SessionController(SessionServiceInterface sessionService, SessionMapper sessionMapper) {
+        this.sessionService = sessionService;
+        this.sessionMapper = sessionMapper;
+    }
 
     @GetMapping
     public ResponseEntity<List<SessionDTO>> getAllSessions() {

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/security/SecurityConfig.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/security/SecurityConfig.java
@@ -1,6 +1,4 @@
 package br.edu.ufape.plataforma.mentoria.security;
-
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -17,8 +15,11 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 public class SecurityConfig {
 
-    @Autowired
-    private SecurityFilter securityFilter;
+    private final SecurityFilter securityFilter;
+
+    public SecurityConfig(SecurityFilter securityFilter) {
+        this.securityFilter = securityFilter;
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/security/SecurityFilter.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/security/SecurityFilter.java
@@ -2,7 +2,6 @@ package br.edu.ufape.plataforma.mentoria.security;
 
 import java.io.IOException;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -18,11 +17,13 @@ import jakarta.servlet.http.HttpServletResponse;
 @Component
 public class SecurityFilter extends OncePerRequestFilter {
 
-    @Autowired
-    private TokenService tokenService;
+    private final TokenService tokenService;
+    private final UserRepository userRepository;
 
-    @Autowired
-    private UserRepository userRepository;
+    public SecurityFilter(TokenService tokenService, UserRepository userRepository) {
+        this.tokenService = tokenService;
+        this.userRepository = userRepository;
+    }
 
     @SuppressWarnings("null")
     @Override

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/AuthService.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/AuthService.java
@@ -3,7 +3,6 @@ package br.edu.ufape.plataforma.mentoria.service;
 import br.edu.ufape.plataforma.mentoria.model.User;
 import br.edu.ufape.plataforma.mentoria.dto.UserDTO;
 import br.edu.ufape.plataforma.mentoria.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -17,11 +16,13 @@ import org.springframework.web.server.ResponseStatusException;
 @Service
 public class AuthService implements UserDetailsService {
 
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+    public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/MentorSearchService.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/MentorSearchService.java
@@ -7,7 +7,6 @@ import br.edu.ufape.plataforma.mentoria.mapper.MentorMapper;
 import br.edu.ufape.plataforma.mentoria.model.Mentor;
 import br.edu.ufape.plataforma.mentoria.repository.MentorRepository;
 import br.edu.ufape.plataforma.mentoria.service.contract.MentorSearchServiceInterface;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -18,11 +17,13 @@ import java.util.stream.Collectors;
 @Service
 public class MentorSearchService implements MentorSearchServiceInterface {
 
-    @Autowired
-    private MentorRepository mentorRepository;
+    private final MentorRepository mentorRepository;
+    private final MentorMapper mentorMapper;
 
-    @Autowired
-    private MentorMapper mentorMapper;
+    public MentorSearchService(MentorRepository mentorRepository, MentorMapper mentorMapper) {
+        this.mentorRepository = mentorRepository;
+        this.mentorMapper = mentorMapper;
+    }
 
     @Override
     public Mentor getMentorById(Long id) {

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/MentorService.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/MentorService.java
@@ -1,7 +1,6 @@
 package br.edu.ufape.plataforma.mentoria.service;
 
 import br.edu.ufape.plataforma.mentoria.service.contract.MentorServiceInterface;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -17,17 +16,20 @@ import br.edu.ufape.plataforma.mentoria.repository.UserRepository;
 
 @Service
 public class MentorService implements MentorServiceInterface {
-    @Autowired
-    private MentorRepository mentorRepository;
+    private final MentorRepository mentorRepository;
+    private final MentorMapper mentorMapper;
+    private final UserRepository userRepository;
+    private final MentorSearchService mentorSearchService;
 
-    @Autowired
-    private MentorMapper mentorMapper;
-
-    @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
-    private MentorSearchService mentorSearchService;
+    public MentorService(MentorRepository mentorRepository,
+                        MentorMapper mentorMapper,
+                        UserRepository userRepository,
+                        MentorSearchService mentorSearchService) {
+        this.mentorRepository = mentorRepository;
+        this.mentorMapper = mentorMapper;
+        this.userRepository = userRepository;
+        this.mentorSearchService = mentorSearchService;
+    }
 
     @Override
     public MentorDTO createMentor(MentorDTO mentorDTO) {

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/MentoredSearchService.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/MentoredSearchService.java
@@ -7,7 +7,6 @@ import br.edu.ufape.plataforma.mentoria.mapper.MentoredMapper;
 import br.edu.ufape.plataforma.mentoria.model.Mentored;
 import br.edu.ufape.plataforma.mentoria.repository.MentoredRepository;
 import br.edu.ufape.plataforma.mentoria.service.contract.MentoredSearchServiceInterface;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -18,10 +17,13 @@ import java.util.stream.Collectors;
 @Service
 public class MentoredSearchService implements MentoredSearchServiceInterface {
 
-    @Autowired
-    private MentoredRepository mentoredRepository;
-    @Autowired
-    private MentoredMapper mentoredMapper;
+    private final MentoredRepository mentoredRepository;
+    private final MentoredMapper mentoredMapper;
+
+    public MentoredSearchService(MentoredRepository mentoredRepository, MentoredMapper mentoredMapper) {
+        this.mentoredRepository = mentoredRepository;
+        this.mentoredMapper = mentoredMapper;
+    }
 
     // Buscar mentorados por id //
     @Override

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/MentoredService.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/MentoredService.java
@@ -5,7 +5,6 @@ import java.util.List;
 import br.edu.ufape.plataforma.mentoria.model.User;
 import br.edu.ufape.plataforma.mentoria.repository.UserRepository;
 import br.edu.ufape.plataforma.mentoria.service.contract.MentoredServiceInterface;
-import org.springframework.beans.factory.annotation.Autowired;
 import br.edu.ufape.plataforma.mentoria.dto.MentoredDTO;
 import br.edu.ufape.plataforma.mentoria.dto.UpdateMentoredDTO;
 import br.edu.ufape.plataforma.mentoria.exceptions.AttributeAlreadyInUseException;
@@ -20,17 +19,20 @@ import org.springframework.stereotype.Service;
 @Service
 public class MentoredService implements MentoredServiceInterface {
 
-    @Autowired
-    private MentoredRepository mentoredRepository;
+    private final MentoredRepository mentoredRepository;
+    private final MentoredSearchService mentoredSearchService;
+    private final MentoredMapper mentoredMapper;
+    private final UserRepository userRepository;
 
-    @Autowired
-    private MentoredSearchService mentoredSearchService;
-
-    @Autowired
-    private MentoredMapper mentoredMapper;
-
-    @Autowired
-    private UserRepository userRepository;
+    public MentoredService(MentoredRepository mentoredRepository,
+                           MentoredSearchService mentoredSearchService,
+                           MentoredMapper mentoredMapper,
+                           UserRepository userRepository) {
+        this.mentoredRepository = mentoredRepository;
+        this.mentoredSearchService = mentoredSearchService;
+        this.mentoredMapper = mentoredMapper;
+        this.userRepository = userRepository;
+    }
 
     @Override
     public List<Mentored> getAllMentored() {

--- a/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/SessionService.java
+++ b/backend/plataforma.mentoria/src/main/java/br/edu/ufape/plataforma/mentoria/service/SessionService.java
@@ -10,7 +10,6 @@ import br.edu.ufape.plataforma.mentoria.repository.MentorRepository;
 import br.edu.ufape.plataforma.mentoria.repository.MentoredRepository;
 import br.edu.ufape.plataforma.mentoria.repository.SessionRepository;
 import br.edu.ufape.plataforma.mentoria.service.contract.SessionServiceInterface;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import br.edu.ufape.plataforma.mentoria.enums.Status;
 
@@ -19,17 +18,20 @@ import java.util.stream.Collectors;
 
 @Service
 public class SessionService implements SessionServiceInterface {
-    @Autowired
-    private SessionRepository sessionRepository;
+    private final SessionRepository sessionRepository;
+    private final SessionMapper sessionMapper;
+    private final MentorRepository mentorRepository;
+    private final MentoredRepository mentoredRepository;
 
-    @Autowired
-    private SessionMapper sessionMapper;
-
-    @Autowired
-    private MentorRepository mentorRepository;
-
-    @Autowired
-    private MentoredRepository mentoredRepository;
+    public SessionService(SessionRepository sessionRepository,
+                         SessionMapper sessionMapper,
+                         MentorRepository mentorRepository,
+                         MentoredRepository mentoredRepository) {
+        this.sessionRepository = sessionRepository;
+        this.sessionMapper = sessionMapper;
+        this.mentorRepository = mentorRepository;
+        this.mentoredRepository = mentoredRepository;
+    }
 
     @Override
     public Session getSessionById(Long id) {


### PR DESCRIPTION
## Descrição

Este PR refatora a forma de injeção de dependências no serviço, removendo o uso de `@Autowired` em campos e padronizando para **injeção por construtor**.  
A mudança visa melhorar a legibilidade, seguir boas práticas do Spring e facilitar a testabilidade do código.

---

## Correções

- N/A

---

## Melhorias

- Remove injeção por campo (`@Autowired` em atributos).
- Adota injeção por construtor para garantir maior imutabilidade e boas práticas.
- Padroniza o código para evitar inconsistências entre classes de serviço.

---

## Tipo de mudança

- [ ] Correção de bug (mudança que não quebra nada e corrige um problema)
- [ ] Nova funcionalidade (mudança que não quebra nada e adiciona funcionalidade)
- [ ] Requer uma atualização na documentação
- [ ] Contém `migrate`
- [ ] Adição de novas dependências
- [ ] Alteração da configuração de ambiente local (ex: .env, Docker, scripts)
- [x] Melhoria interna/refatoração

---

## Relevância

- [ ] Alta: bloqueia deploys, corrige falhas graves ou impede o uso da aplicação
- [ ] Média: corrige comportamentos incorretos, melhora a usabilidade ou a segurança
- [x] Baixa: ajustes visuais, pequenas melhorias internas ou refatorações sem impacto direto

---

## Issues relacionadas

- Close #248 